### PR TITLE
Fix product form validation: conditionally render brand field for variants

### DIFF
--- a/src/components/dashboard/seller/forms/product-details.tsx
+++ b/src/components/dashboard/seller/forms/product-details.tsx
@@ -122,29 +122,6 @@ const ProductDetails: FC<ProductDetailsProps> = ({
 
 	// Is new variant page - only if we have BOTH productId and name (existing product) but no variantId
 	const isNewVariantPage = data?.productId && data?.name && !data?.variantId;
-	
-	// Debug: Force show all fields for debugging
-	const debugForceShowAllFields = true;
-	
-	// Debug: log the values
-	console.log("Debug - Form render:", {
-		isNewVariantPage,
-		data: data ? { productId: data.productId, variantId: data.variantId, name: data.name } : 'No data'
-	});
-	
-	// Alert for debugging
-	alert(`isNewVariantPage: ${isNewVariantPage}, debugForceShowAllFields: ${debugForceShowAllFields}`);
-	
-	// Debug: Log current form values
-	useEffect(() => {
-		const currentValues = form.getValues();
-		console.log("Debug - Current form values:", {
-			name: currentValues.name,
-			variantName: currentValues.variantName,
-			brand: currentValues.brand,
-			description: currentValues.description
-		});
-	}, []);
 
 	// State for subCategories
 	const [subCategories, setSubCategories] = useState<subcategory[]>([]);
@@ -758,19 +735,21 @@ const ProductDetails: FC<ProductDetailsProps> = ({
 									Informazioni tecniche del prodotto. Lo SKU deve essere unico.
 								</FormDescription>
 								<div className="flex flex-col lg:flex-row gap-4">
-										<FormField
-											disabled={isLoading}
-											control={form.control}
-											name="brand"
-											render={({ field }) => (
-												<FormItem className="flex-1">
-													<FormControl>
-													<Input placeholder="es. Nike, Adidas, Zara" {...field} />
-													</FormControl>
-													<FormMessage />
-												</FormItem>
+										{!isNewVariantPage && (
+											<FormField
+												disabled={isLoading}
+												control={form.control}
+												name="brand"
+												render={({ field }) => (
+													<FormItem className="flex-1">
+														<FormControl>
+														<Input placeholder="es. Nike, Adidas, Zara" {...field} />
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+											)}
+										/>
 										)}
-									/>
 									<FormField
 										disabled={isLoading}
 										control={form.control}


### PR DESCRIPTION
# Fix product form validation: conditionally render brand field for variants

## Summary
Fixed a validation error in the product details form by making the brand field conditional. The brand field now only renders when creating/editing products, not when creating variants (since variants inherit the brand from their parent product).

**Key changes:**
- Wrapped brand FormField with `{!isNewVariantPage && ...}` condition
- Removed debug code (console.logs, alerts, unused constants) 
- Aligns with existing label behavior that shows "Marca, SKU e Peso" vs "SKU e Peso" based on context
- Follows same pattern used by other product-level fields in the form

## Review & Testing Checklist for Human
This PR has **moderate risk** due to form validation complexity and inability to test locally due to environment dependency conflicts.

- [ ] **Test new product creation** - Verify brand field is visible and required when creating a new product
- [ ] **Test variant creation** - Verify brand field is hidden when adding a variant to existing product, and form validates/submits successfully  
- [ ] **Test form layout** - Confirm the form layout looks correct in both scenarios (with/without brand field)
- [ ] **Verify variant inheritance** - Ensure variants properly inherit brand value from parent product data
- [ ] **Test existing product editing** - Verify brand field is visible when editing existing products

### Notes
- The brand field remains required in the schema but gets its value from `data?.brand` for variants
- Pattern matches other conditional fields like shipping fee method (lines 1083, 1121)  
- Link to Devin run: https://app.devin.ai/sessions/eee14e8856104da18992fdda1893a72d
- Requested by: @mikbell (Michele Campanello)